### PR TITLE
CATS-2142 | Reenable spellchecking

### DIFF
--- a/resources/ext.CodeMirror.js
+++ b/resources/ext.CodeMirror.js
@@ -135,8 +135,7 @@
 					End: 'goLineRight'
 				},
 				inputStyle: enableContentEditable ? 'contenteditable' : 'textarea',
-				// CATS-2136 temporarily disable spellcheck due to a performance issue in Chrome v96
-				spellcheck: false,
+				spellcheck: enableContentEditable,
 				viewportMargin: Infinity
 			} );
 			$codeMirror = $( codeMirror.getWrapperElement() );


### PR DESCRIPTION
Chrome 97 is out now which should resolve the performance regression
present in Chrome 96.